### PR TITLE
implement scale comms in python

### DIFF
--- a/brewcop.py
+++ b/brewcop.py
@@ -14,7 +14,7 @@ import urwid
 import subprocess
 import serial
 
-poll_period = 2
+poll_period = 0.5
 
 
 class Scale:

--- a/brewcop.py
+++ b/brewcop.py
@@ -75,7 +75,7 @@ class Scale:
     @property
     def display(self):
         if self._weight_is_valid:
-            return "{:.1f}g".format(self._weight)
+            return "{:.0f}g".format(self._weight)
         elif self.ecr_status == b"10" or self.ecr_status == b"30":
             return "moving"
         # elif self.ecr_status == b"20":

--- a/brewcop.py
+++ b/brewcop.py
@@ -79,17 +79,17 @@ class Scale:
     @property
     def display(self):
         if self._weight_is_valid:
-            return "{:.0f}g".format(self._weight - self.tare_offset)
-        elif self.ecr_status == b"10" or self.ecr_status == b"30":
-            return "moving"
+            return ("green", "{:.0f}g".format(self._weight - self.tare_offset))
+        elif self.ecr_status == b"10" or self.ecr_status == b"30": # moving
+            return ("deselect", "{:.0f}g".format(self._weight - self.tare_offset))
         # elif self.ecr_status == b"20":
         #    return "-0-"
         elif self.ecr_status == b"01" or self.ecr_status == b"11":
-            return "under"
+            return ("red", "under")
         elif self.ecr_status == b"02":
-            return "over"
+            return ("red", "over")
         else:
-            return "status:" + self.ecr_status.decode("utf-8")
+            return ("red", "status:" + self.ecr_status.decode("utf-8"))
 
     @property
     def weight_is_valid(self):

--- a/brewcop.py
+++ b/brewcop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ##############################################################
 #  Copyright 2019 Jim Garlick <garlick.jim@gmail.com>
@@ -16,7 +16,7 @@ import subprocess
 poll_period = 2
 
 
-class Scale(object):
+class Scale:
     path_helper = "/usr/local/bin/scale_query"
 
     def __init__(self):
@@ -39,7 +39,7 @@ class Scale(object):
 
 
 # Placeholder for "application logic"
-class Brewcop(object):
+class Brewcop:
     valid_modes = ["beans", "brew", "clean"]
 
     def __init__(self):

--- a/brewcop.py
+++ b/brewcop.py
@@ -24,6 +24,7 @@ class Scale:
         self._weight = 0.0
         self._weight_is_valid = False
         self.ecr_status = None
+        self.tare_offset = 0.0
 
         self.ser = serial.Serial()
         self.ser.port = self.path_serial
@@ -72,10 +73,13 @@ class Scale:
             self.ecr_set_status(response)
             self._weight_is_valid = False
 
+    def tare(self):
+        self.tare_offset = self._weight;
+
     @property
     def display(self):
         if self._weight_is_valid:
-            return "{:.0f}g".format(self._weight)
+            return "{:.0f}g".format(self._weight - self.tare_offset)
         elif self.ecr_status == b"10" or self.ecr_status == b"30":
             return "moving"
         # elif self.ecr_status == b"20":
@@ -93,7 +97,7 @@ class Scale:
 
     @property
     def weight(self):
-        return self._weight
+        return self._weight - self.tare_offset
 
 
 # Placeholder for "application logic"
@@ -205,7 +209,7 @@ def on_clean(w, state):
 
 def on_tare(w):
     try:
-        instrument.zero()
+        instrument.tare()
     except:
         indicator.set_text(("red", "tare"))
     else:


### PR DESCRIPTION
This PR tightens up the interface between brewcop.py and the scale by communicating directly using PySerial, rather than calling out to the C program.  This seems to have reduced the amount of time that the event loop is blocked waiting for the scale.  The polling interval is reduced to 0.5s from 2s, and scale states such as under/over are now displayed properly.

The **tare** button now actually zeroes the scale (so the zero is reflected in the main scale readout).