### PR TITLE
replace buttons with scale-driven mode change

### DIFF
--- a/brewcop.py
+++ b/brewcop.py
@@ -14,10 +14,12 @@ import urwid
 import subprocess
 import serial
 
-poll_period = 0.5
-
 
 class Scale:
+    """
+    Manage the Avery-Berkel 6702-16658 bench scale in ECR mode.
+    """
+
     path_serial = "/dev/ttyAMA0"
 
     def __init__(self):
@@ -39,13 +41,14 @@ class Scale:
         self.ser.open()
 
     def ecr_set_status(self, response):
+        """Parse response and set internal ECR status"""
         assert len(response) == 6
         assert response[0:2] == b"\nS"
         assert response[4:5] == b"\r"
         self.ecr_status = response[2:4]
 
     def ecr_read(self):
-        # Read to EOT (\x03)
+        """Read to ECR EOT (3)"""
         message = bytearray()
         while len(message) == 0 or message[-1] != 3:
             ch = self.ser.read(size=1)
@@ -54,12 +57,18 @@ class Scale:
         return message
 
     def zero(self):
+        """Send ECR Zero command to the scale and read back status"""
         self.ser.reset_input_buffer()
         self.ser.write(b"Z\r")
         response = self.ecr_read()
         self.ecr_set_status(response)
 
     def poll(self):
+        """
+        Send ECR Weigh command to the scale and read back either
+        weight + status, or just status.  If a valid weight is returned,
+        set _weight_is_valid True and convert pounds to grams.
+        """
         self.ser.reset_input_buffer()
         self.ser.write(b"W\r")
         response = self.ecr_read()
@@ -74,16 +83,30 @@ class Scale:
             self._weight_is_valid = False
 
     def tare(self):
-        self.tare_offset = self._weight;
+        """Incorporate weight of container on scale into future measurements"""
+        self.tare_offset = self._weight
+
+    @property
+    def at_zero(self):
+        """
+        Test if scale status indicates scale is at zero.  The zero LED
+        on the scale will be lit in this case.
+        """
+        if self.ecr_status == b"20":
+            return True
+        return False
 
     @property
     def display(self):
+        """
+        Get formatted text for scale readout.
+        Gray out previous value if scale is in motion.
+        Show red over/under on scale range error.
+        """
         if self._weight_is_valid:
             return ("green", "{:.0f}g".format(self._weight - self.tare_offset))
-        elif self.ecr_status == b"10" or self.ecr_status == b"30": # moving
+        elif self.ecr_status == b"10" or self.ecr_status == b"30":  # moving
             return ("deselect", "{:.0f}g".format(self._weight - self.tare_offset))
-        # elif self.ecr_status == b"20":
-        #    return "-0-"
         elif self.ecr_status == b"01" or self.ecr_status == b"11":
             return ("red", "under")
         elif self.ecr_status == b"02":
@@ -93,15 +116,21 @@ class Scale:
 
     @property
     def weight_is_valid(self):
+        """Return True if most recent poll() returned a valid weight."""
         return self._weight_is_valid
 
     @property
     def weight(self):
+        """Return most recently measured weight, less tare offset if any."""
         return self._weight - self.tare_offset
 
 
 # For testing UI without scale present
 class NoScale(Scale):
+    """
+    Dummy version of scale class for UI testing.
+    """
+
     def __init__(self):
         self._weight = 0.0
         self._weight_is_valid = True
@@ -117,22 +146,53 @@ class NoScale(Scale):
 
     @property
     def display(self):
-        return ("deselect", "no scale");
+        return ("deselect", "no scale")
 
 
-# Tuples of (Key, font color, background color)
-palette = [
-    ("background", "dark blue", ""),
-    ("deselect", "dark gray", ""),
-    ("select", "dark green", ""),
-    ("green", "dark green", ""),
-    ("red", "dark red", ""),
-]
+class Progress_mL(urwid.ProgressBar):
+    """
+    Progress bar that displays mL value instead of percentage.
+    It assumes range was set to (0, max capacity in mL).
+    """
 
-# Source: https://www.asciiart.eu/food-and-drinks/coffee-and-tea
-# N.B. this one had no attribution on that site except author's initials,
-# and it seems to be widely disseminated.  Public domain?
-coffee_cup = u'''\
+    def get_text(self):
+        return "{:.0f} mL".format(self.current)
+
+
+class Brewcop:
+    """
+    Main Brewcop class.
+    """
+
+    tick_period = 0.5
+
+    """Values for Technivorm Moccamaster insulated carafe"""
+    pot_tare_g = 796
+    pot_capacity_g = 1250  # 1g per mL H20
+
+    banner_msg = ("green", "B R E W C O P")
+    off_msg = ("red", "Brewcop is offline. Replace pot to begin monitoring...")
+
+    """
+    Urwid color palette.
+    Tuples of (Key, font color, background color)
+    """
+    palette = [
+        ("background", "dark blue", ""),
+        ("deselect", "dark gray", ""),
+        ("select", "dark green", ""),
+        ("green", "dark green", ""),
+        ("red", "dark red", ""),
+        ("pb_todo", "black", "dark red"),
+        ("pb_done", "black", "dark green"),
+    ]
+
+    """
+    Source: https://www.asciiart.eu/food-and-drinks/coffee-and-tea
+    N.B. this one had no attribution on that site except author's initials,
+    and it seems to be widely disseminated.  Public domain?
+    """
+    coffee_cup = u'''\
                       (
                         )     (
                  ___...(-------)-....___
@@ -157,54 +217,134 @@ jgs \""--..__                              __..--""/
                       `"""----"""`
 '''
 
-try:
-    instrument = Scale()
-except:
-    instrument = NoScale()
+    def __init__(self):
+        try:
+            self.scale = Scale()
+        except:
+            self.scale = NoScale()
+        self._indicator = urwid.Text("", align="right")
+        self._meter = urwid.BigText("", urwid.Thin6x6Font())
+        self._online = False
+        self.banner = urwid.Text(self.banner_msg, align="left")
+        self.status = urwid.Text(self.off_msg, align="center")
+        self.pbar = Progress_mL("pb_todo", "pb_done", 0, self.pot_capacity_g)
+        self.background = self.init_background(self.coffee_cup)
+        self.meterbody = self.init_meterbody(self._meter, self.background)
+        self.header = urwid.Columns([self.banner, self._indicator], 2)
+        self.layout = urwid.Frame(
+            header=self.header, body=self.meterbody, footer=self.status
+        )
+        self.main_loop = urwid.MainLoop(
+            self.layout, self.palette, unhandled_input=self.handle_input
+        )
 
-banner = urwid.Text(("green", "B R E W C O P"), align="left")
+    def init_background(self, text):
+        """Return the background ascii art text, properly padded and filled."""
+        bg = urwid.Text(text)
+        bg = urwid.AttrMap(bg, "background")
+        bg = urwid.Padding(bg, align="center", width=56)
+        bg = urwid.Filler(bg)
+        return bg
 
-indicator = urwid.Text("", align="right")
+    def init_meterbody(self, text, background):
+        """Return meter overlayed on background."""
+        m = urwid.AttrMap(text, "green")
+        m = urwid.Padding(m, align="center", width="clip")
+        m = urwid.Filler(m, "bottom", None, 7)
+        m = urwid.LineBox(m)
+        m = urwid.Overlay(m, background, "center", 50, "middle", 8)
+        return m
 
-background = urwid.Text(coffee_cup)
-background = urwid.AttrMap(background, "background")
-background = urwid.Padding(background, align="center", width=56)
-background = urwid.Filler(background)
+    @property
+    def indicator(self):
+        """Get the indicator text (upper right in header)"""
+        self._indicator.get_text()
 
-meter = urwid.BigText("no scale", urwid.Thin6x6Font())
-meter_box = urwid.AttrMap(meter, "green")
-meter_box = urwid.Padding(meter_box, align="center", width="clip")
-meter_box = urwid.Filler(meter_box, "bottom", None, 7)
-meter_box = urwid.LineBox(meter_box)
+    @indicator.setter
+    def indicator(self, value):
+        """Set the indicator text (upper right in header)"""
+        self._indicator.set_text(value)
+
+    @property
+    def meter(self):
+        """Get the meter text (scale reading)"""
+        self._meter.get_text()
+
+    @meter.setter
+    def meter(self, value):
+        """Set the meter text (scale reading)"""
+        self._meter.set_text(value)
+
+    @property
+    def online(self):
+        """Get online status (True or False)"""
+        return self._online
+
+    @online.setter
+    def online(self, value):
+        """
+        Set online status (True or False).
+        If online, hide the meter and show coffee progress bar.
+        If offline, show the meter and replace progress bar with offline msg.
+        """
+        if self._online and not value:
+            self._online = False
+            self.layout.body = self.meterbody
+            self.layout.footer = self.status
+        elif not self._online and value:
+            self._online = True
+            self.layout.body = self.background
+            self.layout.footer = self.pbar
+
+    def handle_input(self, key):
+        """
+        urwid's event loop calls this function on keyboard events
+        not handled by widgets.
+        """
+        if key == "Q" or key == "q":
+            raise urwid.ExitMainLoop()
+
+    def poll_scale(self):
+        """
+        Poll the current scale value.
+        Pulse the indicator green so we get visual feedback if this is slow.
+        The urwid event loop is stalled while this is happening.
+        If it fails, leave the indicator red and set the meter value to ----.
+        """
+        self.indicator = ("green", "poll")
+        self.main_loop.draw_screen()
+        try:
+            self.scale.poll()
+        except:
+            self.indicator = ("red", "poll")
+            self.meter = "----"
+        else:
+            self.indicator = ""
+            self.meter = self.scale.display
+
+    def tick(self, _loop, _data):
+        """
+        urwid's event loop calls this function on tick_period intervals.
+        Read the scale, then update the meter and the progress bar.
+        Switch online mode depending on weight reading.
+        """
+        self.poll_scale()
+        if self.scale.weight_is_valid:
+            w = self.scale.weight - self.pot_tare_g
+            if w < 0:
+                self.online = False
+            else:
+                self.pbar.set_completion(w)
+                self.online = True
+        self.main_loop.set_alarm_in(self.tick_period, self.tick)
+
+    def run(self):
+        """Enter urwid's event loop.  Start ticker and handle input"""
+        self.main_loop.set_alarm_in(0, self.tick)
+        self.main_loop.run()
 
 
-def poll_scale(_loop, _data):
-    indicator.set_text(("green", "poll"))
-    main_loop.draw_screen()
-    try:
-        instrument.poll()
-    except:
-        indicator.set_text(("red", "poll"))
-        meter.set_text("----")
-    else:
-        indicator.set_text("")
-        meter.set_text(instrument.display)
-        #if instrument.weight_is_valid:
-        #    brewcop.weight = instrument.weight
-    main_loop.set_alarm_in(poll_period, poll_scale)
-
-
-def handle_input(key):
-    if key == "Q" or key == "q":
-        raise urwid.ExitMainLoop()
-
-
-header = urwid.Columns([banner, indicator], 2)
-body = urwid.Overlay(meter_box, background, "center", 50, "middle", 8)
-
-layout = urwid.Frame(header=header, body=body)
-main_loop = urwid.MainLoop(layout, palette, unhandled_input=handle_input)
-main_loop.set_alarm_in(0, poll_scale)
-main_loop.run()
+brewcop = Brewcop()
+brewcop.run()
 
 # vim: tabstop=4 shiftwidth=4 expandtab

--- a/brewcop.py
+++ b/brewcop.py
@@ -171,7 +171,7 @@ class Brewcop:
     pot_capacity_g = 1250  # 1g per mL H20
 
     banner_msg = ("green", "B R E W C O P")
-    off_msg = ("red", "Brewcop is offline. Replace pot to begin monitoring...")
+    off_msg = ("red", "Brewcop is offline. Replace pot to continue monitoring...")
 
     """
     Urwid color palette.

--- a/brewcop.py
+++ b/brewcop.py
@@ -120,33 +120,6 @@ class NoScale(Scale):
         return ("deselect", "no scale");
 
 
-# Placeholder for "application logic"
-class Brewcop:
-    valid_modes = ["beans", "brew", "clean"]
-
-    def __init__(self):
-        self._mode = "beans"
-        self._weight = 0.0
-
-    @property
-    def mode(self):
-        return self._mode
-
-    @mode.setter
-    def mode(self, value):
-        if not value in self.valid_modes:
-            raise ValueError("Invalid mode")
-        self._mode = value
-
-    @property
-    def weight(self):
-        return self._weight
-
-    @weight.setter
-    def weight(self, value):
-        self._weight = value
-
-
 # Tuples of (Key, font color, background color)
 palette = [
     ("background", "dark blue", ""),
@@ -189,8 +162,6 @@ try:
 except:
     instrument = NoScale()
 
-brewcop = Brewcop()
-
 banner = urwid.Text(("green", "B R E W C O P"), align="left")
 
 indicator = urwid.Text("", align="right")
@@ -218,8 +189,8 @@ def poll_scale(_loop, _data):
     else:
         indicator.set_text("")
         meter.set_text(instrument.display)
-        if instrument.weight_is_valid:
-            brewcop.weight = instrument.weight
+        #if instrument.weight_is_valid:
+        #    brewcop.weight = instrument.weight
     main_loop.set_alarm_in(poll_period, poll_scale)
 
 

--- a/brewcop.py
+++ b/brewcop.py
@@ -207,39 +207,6 @@ meter_box = urwid.Filler(meter_box, "bottom", None, 7)
 meter_box = urwid.LineBox(meter_box)
 
 
-def on_beans(w, state):
-    if state:
-        brewcop.mode = "beans"
-        w.set_label(("select", w.label))
-    else:
-        w.set_label(("deselect", w.label))
-
-
-def on_brew(w, state):
-    if state:
-        brewcop.mode = "brew"
-        w.set_label(("select", w.label))
-    else:
-        w.set_label(("deselect", w.label))
-
-
-def on_clean(w, state):
-    if state:
-        brewcop.mode = "clean"
-        w.set_label(("select", w.label))
-    else:
-        w.set_label(("deselect", w.label))
-
-
-def on_tare(w):
-    try:
-        instrument.tare()
-    except:
-        indicator.set_text(("red", "tare"))
-    else:
-        indicator.set_text(("green", "tare"))
-
-
 def poll_scale(_loop, _data):
     indicator.set_text(("green", "poll"))
     main_loop.draw_screen()
@@ -261,25 +228,10 @@ def handle_input(key):
         raise urwid.ExitMainLoop()
 
 
-rgroup = []
-
-beans = urwid.RadioButton(rgroup, ("select", "Beans"), on_state_change=on_beans)
-beans = urwid.LineBox(beans)
-
-brew = urwid.RadioButton(rgroup, ("deselect", "Brew"), on_state_change=on_brew)
-brew = urwid.LineBox(brew)
-
-clean = urwid.RadioButton(rgroup, ("deselect", "Clean"), on_state_change=on_clean)
-clean = urwid.LineBox(clean)
-
-tare = urwid.Button("Tare", on_press=on_tare)
-tare = urwid.LineBox(tare)
-
 header = urwid.Columns([banner, indicator], 2)
 body = urwid.Overlay(meter_box, background, "center", 50, "middle", 8)
-footer = urwid.GridFlow([beans, brew, clean, tare], 14, 4, 0, "center")
 
-layout = urwid.Frame(header=header, body=body, footer=footer)
+layout = urwid.Frame(header=header, body=body)
 main_loop = urwid.MainLoop(layout, palette, unhandled_input=handle_input)
 main_loop.set_alarm_in(0, poll_scale)
 main_loop.run()

--- a/brewcop.py
+++ b/brewcop.py
@@ -100,6 +100,26 @@ class Scale:
         return self._weight - self.tare_offset
 
 
+# For testing UI without scale present
+class NoScale(Scale):
+    def __init__(self):
+        self._weight = 0.0
+        self._weight_is_valid = True
+        self.ecr_status = None
+        self.tare_offset = 0.0
+        return
+
+    def poll(self):
+        return
+
+    def zero(self):
+        return
+
+    @property
+    def display(self):
+        return ("deselect", "no scale");
+
+
 # Placeholder for "application logic"
 class Brewcop:
     valid_modes = ["beans", "brew", "clean"]
@@ -164,7 +184,11 @@ jgs \""--..__                              __..--""/
                       `"""----"""`
 '''
 
-instrument = Scale()
+try:
+    instrument = Scale()
+except:
+    instrument = NoScale()
+
 brewcop = Brewcop()
 
 banner = urwid.Text(("green", "B R E W C O P"), align="left")


### PR DESCRIPTION
This PR reimplements the stubbed Brewcop class, pulling in all the global stuff.

Change the logic so that there are only two modes:  offline and online.  Offline displays the scale readout and a message "brewcop is offline".  Online displays a progress bar using hardwired Technivorm pot tare and capacity.  The mode is selected by the scale reading:  offline if scale reads below the pot tare value, else online.  This avoids the somewhat hard to select buttons under X, and allows brewcop to run directly on the console without gpm (which appears to need changes to understand the pi touchscreen).

There is still no slack notification.  Just trying a new user interface.

Other changes:
- Add inline documentation for classes and methods
- Add Scale.at_zero() for testing ECR zero status
- Add NoScale class for limited testing without scale plugged in