### PR TITLE
cleanup, add scale history and status/notify logic

### DIFF
--- a/brewcop.py
+++ b/brewcop.py
@@ -11,7 +11,6 @@
 ##############################################################
 
 import urwid
-import subprocess
 import serial
 
 

--- a/brewcop.py
+++ b/brewcop.py
@@ -31,7 +31,7 @@ class Scale:
         self.ser = serial.Serial()
         self.ser.port = self.path_serial
         self.ser.baudrate = 9600
-        self.ser.sertimeout = 0.25
+        self.ser.timeout = 0.25
         self.ser.parity = serial.PARITY_EVEN
         self.ser.bytesize = serial.SEVENBITS
         self.ser.stopbits = serial.STOPBITS_ONE


### PR DESCRIPTION
This PR fixes a couple of minor bugs, refactors the Brewcop class (extracting a DisplayHelper class for all the urwid stuff), and adds a Brains class that tracks scale weight over time and decides when we are  brewing, ready, or empty.  Upon transition from brewing to ready, it calls a notification stub (currently a no-op).

The current state along with the time elapsed since entering it is shown in the top line of the display, centered.

In addition, if the pot has been in ready state for more than 4h, change the color of the state display red to so poeple know it's stale.